### PR TITLE
remove Prata's "C++ Primer Plus"

### DIFF
--- a/README.md
+++ b/README.md
@@ -769,7 +769,6 @@ The Best Interface Is No Interface: The Simple Path to Brilliant Technology
 
 ### C++
 
-- [📕 C++ primer (1989)](http://www.goodreads.com/book/show/120642.C_Primer_Plus)
 - [📕 Beginning c++ through game programming (2004](http://www.goodreads.com/book/show/852335.Beginning_C_Through_Game_Programming)
 - [📖 C++ core guidelines (2017)](https://github.com/isocpp/CppCoreGuidelines/blob/master/CppCoreGuidelines.md)
 


### PR DESCRIPTION
I don't think that you regularly remove books from your list, but you should definitely reconsider the addition of this book. I read it in the 1990s and still suffer from it (I'm starting to recover, see my pull request #48).

The problem with this book is that it does not teach you real C++, but C++ as an addition to C. Which is grossly out of date, especially with the advent of C++11. I haven't read the current edition, but it seems not to have changed much:

https://www.amazon.com/-/de/gp/customer-reviews/R1254H5KVMF0MQ/ref=cm_cr_arp_d_rvw_ttl?ie=UTF8&ASIN=0321776402

There is also the chance that **this book is in the wrong category**, as the link directs to "**C** primer plus" (both books are regularly mixed up). I have often had that book recommended, so you could probably just move it into the "C" category. But please remove "**C++** primer plus", it remains the worst programming book I have ever read (and I have read about fifty books on many different languages).